### PR TITLE
Migrate site header JS, add woocommerce template, change svg text fill

### DIFF
--- a/generatepress-child/js/header-scroll.js
+++ b/generatepress-child/js/header-scroll.js
@@ -1,0 +1,32 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const header = document.getElementById("masthead");
+  const logo = document.querySelector(".is-logo-image");
+  const nav = document.getElementById("site-navigation");
+  const toggle = document.querySelector(".menu-toggle");
+  let startScrollY = null;
+
+  window.addEventListener("scroll", function () {
+    const currentY = window.scrollY;
+
+    // background + logo swap
+    if (currentY > 0) {
+      header.classList.add("scrolled");
+      logo.src = "https://dev.venture.com.na/wp-content/uploads/2025/09/venture-logo-black.svg";
+    } else {
+      header.classList.remove("scrolled");
+      logo.src = "https://dev.venture.com.na/wp-content/uploads/2025/09/venture-logo-white.svg";
+    }
+
+    // close menu only if moved far enough
+    if (nav.classList.contains("toggled")) {
+      if (startScrollY === null) startScrollY = currentY;
+      if (Math.abs(currentY - startScrollY) > 300) {
+        nav.classList.remove("toggled");
+        toggle.setAttribute("aria-expanded", "false");
+        startScrollY = null;
+      }
+    } else {
+      startScrollY = null;
+    }
+  });
+});

--- a/generatepress-child/woocommerce/single-product.php
+++ b/generatepress-child/woocommerce/single-product.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * The Template for displaying all single products.
+ *
+ * Override this template by copying it to yourtheme/woocommerce/single-product.php
+ *
+ * @author     
+ */
+
+get_header('shop'); ?>
+
+	<div class="row">
+
+	<?php
+		/**
+		 * woocommerce_before_main_content hook
+		 *
+		 * @hooked woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)
+		 * @hooked woocommerce_breadcrumb - 20
+		 */
+		do_action('woocommerce_before_main_content');
+	?>
+
+		<?php while ( have_posts() ) : the_post(); ?>
+
+			<?php woocommerce_get_template_part( 'content', 'single-product' ); ?>
+
+		<?php endwhile; // end of the loop. ?>
+
+	<?php
+		/**
+		 * woocommerce_after_main_content hook
+		 *
+		 * @hooked woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)
+		 */
+		do_action('woocommerce_after_main_content');
+	?>
+
+	<?php
+		/**
+		 * woocommerce_sidebar hook
+		 *
+		 * @hooked woocommerce_get_sidebar - 10
+		 */
+		do_action('woocommerce_sidebar');
+	?>
+
+</div>
+
+<?php get_footer('shop'); ?>

--- a/it-all-starts-with-why.svg
+++ b/it-all-starts-with-why.svg
@@ -15,8 +15,6 @@
    xmlns:svg="http://www.w3.org/2000/svg">
   <sodipodi:namedview
      id="namedview1"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
      borderopacity="0.25"
      inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
@@ -49,67 +47,67 @@
      id="layer1">
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text2"
        transform="matrix(0.69323397,0,0,0.69323397,38.595986,107.92606)"><tspan
          id="tspan1"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:120.278px;font-family:'Melting Stories';-inkscape-font-specification:'Melting Stories, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#221f21;fill-opacity:1;stroke-width:0"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:120.278px;font-family:'Melting Stories';-inkscape-font-specification:'Melting Stories, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#d4d7d9;fill-opacity:1;stroke-width:0"
          x="113.86588"
          y="187.89041">teach</tspan></text>
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text3"
        transform="matrix(0.69323397,0,0,0.69323397,286.41518,7.6750129)">learn</text>
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text4"
        transform="matrix(0.69323397,0,0,0.69323397,595.06012,35.48258)">connect</text>
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text5"
        transform="matrix(0.69323397,0,0,0.69323397,698.00554,205.63975)">create</text>
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text6"
        transform="matrix(0.69323397,0,0,0.69323397,707.17078,375.79692)">contribute</text>
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text7"
        transform="matrix(0.69323397,0,0,0.69323397,693.9471,612.84713)">beauty</text>
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text8"
        transform="matrix(0.69323397,0,0,0.69323397,372.15886,763.34833)">change</text>
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text9"
        transform="matrix(0.69323397,0,0,0.69323397,77.953187,635.52167)">stories</text>
     <text
        xml:space="preserve"
-       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#221f21;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
+       style="stroke-dasharray:none;stroke-width:0;stroke:none;fill-rule:nonzero;fill-opacity:1;fill:#d4d7d9;display:inline;white-space:pre;text-anchor:start;direction:ltr;writing-mode:lr-tb;text-align:start;font-variant-east-asian:normal;font-variant-numeric:normal;font-variant-caps:normal;font-variant-ligatures:normal;-inkscape-font-specification:'Melting Stories, Normal';font-family:'Melting Stories';font-size:30mm;font-stretch:normal;font-weight:normal;font-variant:normal;font-style:normal;"
        x="113.86588"
        y="187.89041"
        id="text10"


### PR DESCRIPTION
- Migrate site header (navigation) JS
- add standard php template for woocommerce single products to child theme
- Change fill for text in svg